### PR TITLE
fix: 修复有/无「更多」时操作列高度不一致导致 Table 跳动

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne/button-group",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "实现了一个按钮组,loading按钮,确认按钮和加载按钮.",
   "syntax": {
     "esmodules": true

--- a/src/ButtonGroup/index.js
+++ b/src/ButtonGroup/index.js
@@ -32,10 +32,11 @@ const ButtonGroup = createWithIntlProvider(
     return undefined;
   }, [list]);
   const isControlled = Number.isInteger(showLengthProps);
-  // 未测量前不展示全部按钮，避免表格行「先变高再回弹」
+  // 未测量前不展示全部按钮，避免表格行「先变高再回弹」；可见区至少留 1 个按钮占位，避免高度先塌再撑起
   const [showLengthState, setShowLength] = useState(0);
   const [ready, setReady] = useState(isControlled);
   const showLength = isControlled ? showLengthProps : showLengthState;
+  const visibleLength = !isControlled && !ready && list.length > 0 ? Math.max(showLength, 1) : showLength;
   const computedLength = useRefCallback(() => {
     const el = targetRef.current,
       moreEl = moreRef.current,
@@ -150,10 +151,10 @@ const ButtonGroup = createWithIntlProvider(
       </div>
       <div className={style['visible-content']}>
         <SpaceComponent {...spaceProps}>
-          {list.slice(0, showLength).map((item, index) => (
+          {list.slice(0, visibleLength).map((item, index) => (
             <Fragment key={index}>{renderButton(item, index, false)}</Fragment>
           ))}
-          {otherList.length > 0 && (
+          {ready && otherList.length > 0 && (
             <Dropdown
               getPopupContainer={getPopupContainer}
               trigger={trigger}

--- a/src/ButtonGroup/style.module.scss
+++ b/src/ButtonGroup/style.module.scss
@@ -30,16 +30,10 @@
   position: absolute;
 }
 
+// 与表格操作列 link 按钮（如 btn-no-padding）同高，避免有/无「更多」时行高在 43/38 间跳动
 .more-link-btn {
   padding-inline: 8px !important;
-
-  &:global(.ant-btn-sm) {
-    padding-block: 0 !important;
-  }
-
-  &:not(:global(.ant-btn-sm)):not(:global(.ant-btn-lg)) {
-    padding-block: 5px !important;
-  }
+  padding-block: 0 !important;
 }
 
 .menu-list {


### PR DESCRIPTION
统一 more-link-btn 上下内边距，并在测量完成前保留按钮占位高度。